### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+        env:
+          BASE_PATH: ${{ github.event.repository.name }}
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ export default tseslint.config({
 })
 ```
 
+## Deploying to GitHub Pages
+
+This project includes a workflow that automatically builds and publishes the
+app using [GitHub Pages](https://pages.github.com/). Every push to the `main`
+branch triggers the workflow which:
+
+1. Installs dependencies and builds the project.
+2. Uploads the generated `dist` folder as a Pages artifact.
+3. Deploys the artifact to GitHub Pages.
+
+The public site will be available at `https://<username>.github.io/<repository>/`
+after the workflow completes.
+
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: process.env.BASE_PATH ? `/${process.env.BASE_PATH}/` : '/',
 })


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy to GitHub Pages
- support setting a dynamic base path in `vite.config.ts`
- document GitHub Pages workflow in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find type definition file for 'babel__core')*

------
https://chatgpt.com/codex/tasks/task_e_684c25dd9c208321a9f543baefce8917