### PR TITLE
Set pale header theme and add home section

### DIFF
--- a/src/Header.css
+++ b/src/Header.css
@@ -4,6 +4,8 @@
   align-items: center;
   gap: 1rem;
   padding: 1rem;
+  background-color: #a8dadc;
+  color: #033649;
 }
 
 .nav {
@@ -21,6 +23,11 @@
   padding: 0.5rem 1rem;
   cursor: pointer;
   transition: box-shadow 0.3s, transform 0.3s;
+}
+
+.nav-button.active {
+  background-color: rgba(255, 255, 255, 0.7);
+  color: #033649;
 }
 
 .nav-button:hover {

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import './Header.css'
 
 const navItems = [
@@ -14,12 +15,18 @@ const navItems = [
 ]
 
 export default function Header() {
+  const [active, setActive] = useState('Home')
+
   return (
     <header className="header">
       <h1 className="title">Cabinet Dentaire Lachine</h1>
       <nav className="nav">
         {navItems.map((item) => (
-          <button key={item} className="nav-button">
+          <button
+            key={item}
+            className={`nav-button${active === item ? ' active' : ''}`}
+            onClick={() => setActive(item)}
+          >
             {item}
           </button>
         ))}

--- a/src/MainPage.css
+++ b/src/MainPage.css
@@ -1,0 +1,11 @@
+.content-card {
+  background-color: #ffffff;
+  color: #333;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 2rem;
+  margin: 2rem auto;
+  max-width: 800px;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.6;
+}

--- a/src/MainPage.tsx
+++ b/src/MainPage.tsx
@@ -1,9 +1,43 @@
 import Header from './Header'
+import './MainPage.css'
 
 export default function MainPage() {
   return (
     <>
       <Header />
+      <main className="content-card">
+        <p>
+          Le CABINETDENTAIRE.ca se positionne comme un centre dentaire qui offre
+          des soins professionnels, accompagnés d’une technologie de pointe qui a fait
+          ses preuves. Une équipe multidisciplinaire nous permet d’offrir une grande
+          gamme de services dentaires au sein même de notre clinique dentaire de
+          Lachine, à Montréal, un avantage indéniable qui évite les déplacements et le
+          transfert de dossiers. Nous préconisons la prévention et la santé dentaire à
+          long terme.
+        </p>
+        <p>
+          Notre but est de vous offrir un beau sourire radieux et durable. Le
+          CABINETDENTAIRE.ca forme une grande famille de professionnels dentaires qui
+          ont à cœur le bien-être et la santé de leurs patients. Nous faisons tout en
+          notre capacité pour vous faire vivre une expérience des plus agréables.
+        </p>
+        <p>
+          Les chirurgiens-dentistes utilisent les technologies récentes, mais qui ont
+          fait leurs preuves; notamment, les restaurations très durables en céramique
+          (CEREC), des lasers diagnostics et chirurgicaux, la radiologie numérique pour
+          moins de radiations et plus de précisions. Une équipe de chirurgiens-dentistes
+          au service de votre dentition depuis 1978.
+        </p>
+        <p>
+          Notre mission: améliorer la santé bucco-dentaire générale de la population,
+          par des soins professionnels et en mettant la meilleure technologie au service
+          des patients. La dentisterie a énormément évolué au cours des dernières années.
+        </p>
+        <p>
+          De plus, au CABINETDENTAIRE.ca, vous pouvez être servi en français, anglais,
+          espagnol, portugais, russe, polonais et roumain.
+        </p>
+      </main>
     </>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: light;
+  color: #213547;
+  background-color: #e0f7fa;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -58,7 +58,7 @@ button:focus-visible {
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
-    background-color: #ffffff;
+    background-color: #e0f7fa;
   }
   a:hover {
     color: #747bff;


### PR DESCRIPTION
## Summary
- style header with a pale green-blue background
- highlight active nav button and default to `Home`
- display introductory text inside a white card
- apply light color scheme

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c4851d4d083219f8d4123a1e8604a