### PR TITLE
Set home page background

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,6 +1,10 @@
-import { useState } from 'react'
 import './Header.css'
 import logo from './assets/logo.jpeg'
+
+interface HeaderProps {
+  active: string
+  onChange: (item: string) => void
+}
 
 const navItems = [
   'Home',
@@ -15,8 +19,7 @@ const navItems = [
   'Contact',
 ]
 
-export default function Header() {
-  const [active, setActive] = useState('Home')
+export default function Header({ active, onChange }: HeaderProps) {
 
   return (
     <header className="header">
@@ -27,7 +30,7 @@ export default function Header() {
           <button
             key={item}
             className={`nav-button${active === item ? ' active' : ''}`}
-            onClick={() => setActive(item)}
+            onClick={() => onChange(item)}
           >
             {item}
           </button>

--- a/src/MainPage.css
+++ b/src/MainPage.css
@@ -33,3 +33,11 @@
     opacity: 1;
   }
 }
+
+.page-wrapper {
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/src/MainPage.tsx
+++ b/src/MainPage.tsx
@@ -1,8 +1,12 @@
+import { useState } from 'react'
 import Header from './Header'
 import './MainPage.css'
 import logo from './assets/logo.jpeg'
+import background1 from './assets/background 1.jpeg'
 
 export default function MainPage() {
+  const [active, setActive] = useState('Home')
+
   const paragraphs = [
     `Le CABINETDENTAIRE.ca se positionne comme un centre dentaire qui offre des soins professionnels, accompagnés d’une technologie de pointe qui a fait ses preuves. Une équipe multidisciplinaire nous permet d’offrir une grande gamme de services dentaires au sein même de notre clinique dentaire de Lachine, à Montréal, un avantage indéniable qui évite les déplacements et le transfert de dossiers. Nous préconisons la prévention et la santé dentaire à long terme.`,
     `Notre but est de vous offrir un beau sourire radieux et durable. Le CABINETDENTAIRE.ca forme une grande famille de professionnels dentaires qui ont à cœur le bien-être et la santé de leurs patients. Nous faisons tout en notre capacité pour vous faire vivre une expérience des plus agréables.`,
@@ -11,9 +15,19 @@ export default function MainPage() {
     `De plus, au CABINETDENTAIRE.ca, vous pouvez être servi en français, anglais, espagnol, portugais, russe, polonais et roumain.`,
   ]
 
+  const wrapperStyle =
+    active === 'Home'
+      ? {
+          backgroundImage: `url(${background1})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          backgroundRepeat: 'no-repeat',
+        }
+      : {}
+
   return (
-    <>
-      <Header />
+    <div className="page-wrapper" style={wrapperStyle}>
+      <Header active={active} onChange={setActive} />
       <main className="content-card">
         <img src={logo} alt="Cabinet Dentaire Logo" className="card-logo" />
         {paragraphs.map((text, index) => (
@@ -22,6 +36,6 @@ export default function MainPage() {
           </div>
         ))}
       </main>
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- manage active menu item in `MainPage`
- update `Header` to receive the active state and callback
- apply background image when the active tab is Home
- add layout wrapper styles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c5fe450388321b867d78ffeb3d0cb