### PR TITLE
Extend home background image

### DIFF
--- a/src/MainPage.css
+++ b/src/MainPage.css
@@ -35,9 +35,21 @@
 }
 
 .page-wrapper {
+  position: relative;
   width: 100%;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+.page-wrapper::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: var(--background-image);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  z-index: -1;
 }

--- a/src/MainPage.tsx
+++ b/src/MainPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { CSSProperties, useState } from 'react'
 import Header from './Header'
 import './MainPage.css'
 import logo from './assets/logo.jpeg'
@@ -15,14 +15,9 @@ export default function MainPage() {
     `De plus, au CABINETDENTAIRE.ca, vous pouvez être servi en français, anglais, espagnol, portugais, russe, polonais et roumain.`,
   ]
 
-  const wrapperStyle =
+  const wrapperStyle: CSSProperties =
     active === 'Home'
-      ? {
-          backgroundImage: `url(${background1})`,
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-          backgroundRepeat: 'no-repeat',
-        }
+      ? ({ '--background-image': `url(${background1})` } as CSSProperties)
       : {}
 
   return (


### PR DESCRIPTION
## Summary
- use CSS variable for wrapper background
- display background using an overlay pseudo-element

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c62b379fc8321b74e90d844397457