### PR TITLE
Switch services background

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -8,7 +8,6 @@ interface HeaderProps {
 
 const navItems = [
   'Home',
-  'À Propos',
   'Services',
   'Conseil',
   'Our team',

--- a/src/MainPage.tsx
+++ b/src/MainPage.tsx
@@ -21,7 +21,7 @@ export default function MainPage() {
     wrapperStyle = {
       '--background-image': `url(${background1})`,
     } as CSSProperties
-  } else if (active === 'À Propos') {
+  } else if (active === 'Services') {
     wrapperStyle = {
       '--background-image': `url(${background2})`,
     } as CSSProperties


### PR DESCRIPTION
## Summary
- remove the `À Propos` button from the navigation bar
- apply `background 2` when the **Services** button is active

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c6babbd04832183b97a71425af6ae