### PR TITLE
Add reveal animation for homepage background

### DIFF
--- a/src/MainPage.css
+++ b/src/MainPage.css
@@ -53,3 +53,16 @@
   background-repeat: no-repeat;
   z-index: -1;
 }
+
+.page-wrapper.reveal::before {
+  animation: reveal-bg 1s ease-out forwards;
+}
+
+@keyframes reveal-bg {
+  from {
+    clip-path: inset(0 0 0 100%);
+  }
+  to {
+    clip-path: inset(0);
+  }
+}

--- a/src/MainPage.tsx
+++ b/src/MainPage.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, useState } from 'react'
+import { CSSProperties, useEffect, useState } from 'react'
 import Header from './Header'
 import './MainPage.css'
 import logo from './assets/logo.jpeg'
@@ -7,6 +7,11 @@ import background2 from './assets/background 2.png'
 
 export default function MainPage() {
   const [active, setActive] = useState('Home')
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    setLoaded(true)
+  }, [])
 
   const paragraphs = [
     `Le CABINETDENTAIRE.ca se positionne comme un centre dentaire qui offre des soins professionnels, accompagnés d’une technologie de pointe qui a fait ses preuves. Une équipe multidisciplinaire nous permet d’offrir une grande gamme de services dentaires au sein même de notre clinique dentaire de Lachine, à Montréal, un avantage indéniable qui évite les déplacements et le transfert de dossiers. Nous préconisons la prévention et la santé dentaire à long terme.`,
@@ -28,7 +33,10 @@ export default function MainPage() {
   }
 
   return (
-    <div className="page-wrapper" style={wrapperStyle}>
+    <div
+      className={`page-wrapper${loaded && active === 'Home' ? ' reveal' : ''}`}
+      style={wrapperStyle}
+    >
       <Header active={active} onChange={setActive} />
       <main className="content-card">
         <img src={logo} alt="Cabinet Dentaire Logo" className="card-logo" />


### PR DESCRIPTION
## Summary
- run reveal clip-path animation on initial load to mimic PowerPoint's Reveal effect

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6de07ea48321864edcd1666882e9