### PR TITLE
Add conseil advice card

### DIFF
--- a/src/MainPage.css
+++ b/src/MainPage.css
@@ -27,6 +27,22 @@
   animation: peek-in 0.6s forwards ease-out;
 }
 
+.advice-card {
+  background-color: #fffdf5;
+  color: #333;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 2rem;
+  margin: 2rem auto;
+  max-width: 800px;
+  font-family: 'Georgia', 'Times New Roman', serif;
+  line-height: 1.8;
+}
+
+.advice-card p {
+  margin-bottom: 1rem;
+}
+
 @keyframes peek-in {
   to {
     transform: translateY(0);

--- a/src/MainPage.tsx
+++ b/src/MainPage.tsx
@@ -28,7 +28,7 @@ export default function MainPage() {
     }
   }, [active])
 
-  const paragraphs = [
+  const homeParagraphs = [
     `Le CABINETDENTAIRE.ca se positionne comme un centre dentaire qui offre des soins professionnels, accompagnés d’une technologie de pointe qui a fait ses preuves. Une équipe multidisciplinaire nous permet d’offrir une grande gamme de services dentaires au sein même de notre clinique dentaire de Lachine, à Montréal, un avantage indéniable qui évite les déplacements et le transfert de dossiers. Nous préconisons la prévention et la santé dentaire à long terme.`,
     `Notre but est de vous offrir un beau sourire radieux et durable. Le CABINETDENTAIRE.ca forme une grande famille de professionnels dentaires qui ont à cœur le bien-être et la santé de leurs patients. Nous faisons tout en notre capacité pour vous faire vivre une expérience des plus agréables.`,
     `Les chirurgiens-dentistes utilisent les technologies récentes, mais qui ont fait leurs preuves; notamment, les restaurations très durables en céramique (CEREC), des lasers diagnostics et chirurgicaux, la radiologie numérique pour moins de radiations et plus de précisions. Une équipe de chirurgiens-dentistes au service de votre dentition depuis 1978.`,
@@ -50,17 +50,34 @@ export default function MainPage() {
     loaded && active === 'Home' ? ' reveal' : ''
   }${fadeImage ? ' fading' : ''}`
 
+  const adviceParagraphs = [
+    "Avant la chirurgie, abstenez-vous de prendre de l’aspirine dix jours à l’avance et d’alcool dans les vingt-quatre heures précédentes. Signalez-nous tout changement à votre dossier médical. Prenez un repas et, si une sédation est prévue, assurez-vous qu’une personne responsable vous accompagne.",
+    "Après l’intervention, mordez une compresse une trentaine de minutes pour contrôler le saignement et suivez la médication prescrite. Ne touchez pas la zone opérée et évitez toute succion pendant vingt-quatre heures, y compris l’usage d’une paille. Ne fumez pas durant cette période.",
+    "Pour dormir, gardez la tête sur deux ou trois oreillers. Un léger saignement est normal; si la perte est plus abondante, mordez une compresse pliée ou un sachet de thé afin de favoriser la coagulation.",
+    "Appliquez de la glace enveloppée d’une serviette humide pendant vingt minutes chaque heure durant les deux premiers jours. Après vingt-quatre heures, rincez-vous la bouche avec de l’eau salée (une cuillerée à thé de sel dans un verre d’eau) quatre fois par jour pendant une semaine.",
+    "Optez pour une alimentation molle et tiède et évitez le surmenage ainsi que les exercices intenses pendant quarante-huit heures. Un gonflement ou des ecchymoses peuvent apparaître sans nécessiter de traitement. Les points de suture se résorberont d’eux-mêmes après environ une semaine.",
+  ]
+
   return (
     <div className={wrapperClass} style={wrapperStyle}>
       <Header active={active} onChange={setActive} />
-      <main className="content-card">
-        <img src={logo} alt="Cabinet Dentaire Logo" className="card-logo" />
-        {paragraphs.map((text, index) => (
-          <div className="peek-container" key={index}>
-            <p className="peek-text" style={{ animationDelay: `${index * 0.2}s` }}>{text}</p>
-          </div>
-        ))}
-      </main>
+      {active === 'Home' && (
+        <main className="content-card">
+          <img src={logo} alt="Cabinet Dentaire Logo" className="card-logo" />
+          {homeParagraphs.map((text, index) => (
+            <div className="peek-container" key={index}>
+              <p className="peek-text" style={{ animationDelay: `${index * 0.2}s` }}>{text}</p>
+            </div>
+          ))}
+        </main>
+      )}
+      {active === 'Conseil' && (
+        <main className="advice-card">
+          {adviceParagraphs.map((text, index) => (
+            <p key={index}>{text}</p>
+          ))}
+        </main>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add new Conseil paragraph content with advice
- style the advice card with a serif font and soft colors
- render advice text when "Conseil" nav item is active

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c744495048321af9598b46baedb27