### PR TITLE
Align header title with icon

### DIFF
--- a/src/Header.css
+++ b/src/Header.css
@@ -19,6 +19,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: relative;
+  padding-bottom: 0.6rem;
 }
 
 .title {
@@ -61,6 +63,10 @@
 
 .tagline {
   margin: 0;
-  font-size: 0.875rem;
+  font-size: 0.6rem;
   font-weight: bold;
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 50%;
+  transform: translateX(-50%);
 }


### PR DESCRIPTION
## Summary
- adjust tagline styles for smaller 'depuis 1978'
- position tagline absolutely so the title aligns with the icon

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684df9c02f1883218ea5a34717ad81d1