### PR TITLE
Increase spacing between tagline and nav

### DIFF
--- a/src/Header.css
+++ b/src/Header.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  gap: 1.2rem;
   padding: 1rem;
   background-color: #a8dadc;
   color: #033649;
@@ -20,7 +20,7 @@
   flex-direction: column;
   align-items: center;
   position: relative;
-  padding-bottom: 0.3rem;
+  padding-bottom: 0.6rem;
 }
 
 .title {


### PR DESCRIPTION
## Summary
- add more padding under the logo to ensure "Depuis 1978" sits above the nav
- slightly increase the header gap to create more vertical space

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684dfe8ea53c832192654ed70f95ce41