### PR TITLE
Adjust header layout for centered title

### DIFF
--- a/src/Header.css
+++ b/src/Header.css
@@ -13,6 +13,8 @@
   display: flex;
   align-items: center;
   gap: 1rem;
+  position: relative;
+  width: 100%;
 }
 
 
@@ -22,6 +24,7 @@
   align-items: center;
   position: relative;
   padding-bottom: 0.3rem;
+  margin-right: 0.5rem;
 }
 
 .title {
@@ -31,6 +34,9 @@
   background: linear-gradient(90deg, #ff9a9e, #fad0c4);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .nav {
@@ -79,4 +85,5 @@
   font-size: 1.1rem;
   font-weight: bold;
   text-align: left;
+  margin-right: auto;
 }


### PR DESCRIPTION
## Summary
- center the header title visually
- keep the icon to the left of the title and push the address to the far left

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e195a63bc83218b204794348dad17